### PR TITLE
adding notifications for KitKat for high and blocker bugs

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,7 @@ const flagOss = require( './tasks/flag-oss' );
 const gatherSupportReferences = require( './tasks/gather-support-references' );
 const notifyDesign = require( './tasks/notify-design' );
 const notifyEditorial = require( './tasks/notify-editorial' );
+const notifyKitKat = require( './tasks/notify-kitkat' );
 const replyToCustomersReminder = require( './tasks/reply-to-customers-reminder' );
 const triageNewIssues = require( './tasks/triage-new-issues' );
 const wpcomCommitReminder = require( './tasks/wpcom-commit-reminder' );
@@ -51,6 +52,11 @@ const automations = [
 		event: 'pull_request_target',
 		action: [ 'labeled' ],
 		task: ifNotClosed( notifyEditorial ),
+	},
+	{
+		event: 'issues',
+		action: [ 'labeled' ],
+		task: ifNotClosed( notifyKitKat ),
 	},
 	{
 		event: 'push',

--- a/src/tasks/notify-kitkat/index.js
+++ b/src/tasks/notify-kitkat/index.js
@@ -1,0 +1,94 @@
+const { getInput, setFailed } = require( '@actions/core' );
+const debug = require( '../../utils/debug' );
+const getLabels = require( '../../utils/get-labels' );
+const sendSlackMessage = require( '../../utils/send-slack-message' );
+
+/* global GitHub, WebhookPayloadIssue */
+
+/**
+ * Check for a high priority label on an issue.
+ *
+ * @param {GitHub} octokit - Initialized Octokit REST client.
+ * @param {string} owner   - Repository owner.
+ * @param {string} repo    - Repository name.
+ * @param {string} number  - Issue number.
+ * @returns {Promise<boolean>} Promise resolving to boolean.
+ */
+async function hasHighPrioLabel( octokit, owner, repo, number ) {
+	const labels = await getLabels( octokit, owner, repo, number );
+	// We're only interested in the [Prio] High label.
+	return labels.includes( '[Prio] High' );
+}
+
+/**
+ * Check for a BLOCKER priority label on an issue.
+ *
+ * @param {GitHub} octokit - Initialized Octokit REST client.
+ * @param {string} owner   - Repository owner.
+ * @param {string} repo    - Repository name.
+ * @param {string} number  - Issue number.
+ * @returns {Promise<boolean>} Promise resolving to boolean.
+ */
+async function hasBlockerPrioLabel( octokit, owner, repo, number ) {
+	const labels = await getLabels( octokit, owner, repo, number );
+	// We're only interested in the [Prio] BLOCKER label.
+	return labels.includes( '[Prio] BLOCKER' );
+}
+
+
+/**
+ * Send a Slack notification about a label to Team KitKat.
+ *
+ * @param {WebhookPayloadIssue} payload - Issue event payload.
+ * @param {GitHub}                    octokit - Initialized Octokit REST client.
+ */
+async function notifyKitKat( payload, octokit ) {
+	const { number, repository } = payload;
+	const { owner, name: repo } = repository;
+	const ownerLogin = owner.login;
+
+	const slackToken = getInput( 'slack_token' );
+	if ( ! slackToken ) {
+		setFailed( `notify-kitkat: Input slack_token is required but missing. Aborting.` );
+		return;
+	}
+
+	const channel = getInput( 'slack_kitkat_channel' );
+	if ( ! channel ) {
+		setFailed(
+			`notify-editorial: Input slack_kitkat_channel is required but missing. Aborting.`
+		);
+		return;
+	}
+
+
+	// Check for a [Prio] High label.
+	const isLabeledHighPriority = await hasHighPrioLabel( octokit, ownerLogin, repo, number );
+	if ( isLabeledHighPriority ) {
+		debug(
+			`notify-kitkat: Found a [Prio] High label on issue #${ number }. Sending in Slack message.`
+		);
+		await sendSlackMessage(
+			`New High priority bug.`,
+			channel,
+			slackToken,
+			payload
+		);
+	}
+
+	// Check for a BLOCKER priority label.
+	const isLabeledBlocker = await hasLabel( octokit, ownerLogin, repo, number );
+	if ( isLabeledBlocker ) {
+		debug(
+			`notify-editorial: Found a [Pri] BLOCKER label on issue #${ number }. Sending in Slack message.`
+		);
+		await sendSlackMessage(
+			`New Blocker bug!.`,
+			channel,
+			slackToken,
+			payload
+		);
+	}
+}
+
+module.exports = notifyKitKat;

--- a/src/tasks/notify-kitkat/readme.md
+++ b/src/tasks/notify-kitkat/readme.md
@@ -1,0 +1,14 @@
+# Notify KitKat
+
+Send a Slack notification to KitKat when there is a high or blocker priority bug, or a bug with no priority label.
+
+This task responds to the following labels:
+
+- "[Pri] BLOCKER"
+- "[Pri] High"
+
+When one of the labels above is added to an issue, a Slack message will be sent to channel of your choice.
+
+## Rationale
+
+This alert will help improve triage times which should then improve MTTR.


### PR DESCRIPTION
This is a WIP in progress to add notifications to #kitkat-daily for high and blocker bugs.

I have mostly copied from notify-editorial on this, and I'm sure I've made some mistakes.

- I have not added the channel id as a secret (yet)
- I think ifNotClosed might need to be updated (or a new function added) to handle issues, as the existing function is geared towards PRs.
- This is my first time working with GitHub actions. I'm unsure if this will fire a notification when any label is added to a bug with the specified labels or only when the specified labels are added. For example, if a bug is labeled [Prio] High, and the notification is sent, and later, someone adds another label such as "Atomic", will this trigger another notification? I ask because notify-editorial has a check on "hasBeenRequested".  If this is the case, I can add a check for the presence of the "needs triage" label, so that we don't send the notification if that label is not present. We will then need to ensure that new bugs start with that label and that we remove it consistently during triage.
- Also, I do not know how to test this, so advice would be greatly appreciated!